### PR TITLE
Convert backslashes to forward slashes (on Windows)

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,6 +105,8 @@ module.exports = function (Mincer) {
         }
 
         var asset = assetPath(rfile);
+        // replace backslashes with forward slashes for Windows
+        asset = asset.replace(/\\/g,'/')
         if (asset) {
           return ["url('", asset, info.tail, "')"].join('');
         }


### PR DESCRIPTION
On a windows machine using Mincer 1.4, we were seeing some converted
url strings from this plugin come out containing backslashes, eg

`url(‘/assets/dist\path\to\image-1234hash.png’)`

I’m actually not certain if it’s really a problem with Mincer, but this
quick regex replace fixed it for us.
